### PR TITLE
Minor interaction fixes

### DIFF
--- a/src/components/Chessboard/Chessboard.tsx
+++ b/src/components/Chessboard/Chessboard.tsx
@@ -46,6 +46,7 @@ export default function Chessboard({ playMove, pieces, whoseTurn }: Props) {
 
       setActivePiece(element)
       setIsClicked(false)
+      document.body.style.userSelect = 'none'
     }
   }
 
@@ -54,7 +55,7 @@ export default function Chessboard({ playMove, pieces, whoseTurn }: Props) {
     const chessboard = chessboardRef.current
     const element = e.target as HTMLElement
 
-    if (element.classList.contains('chess-piece') && chessboard) {
+    if (element.classList.contains('chess-piece') && chessboard && !activePiece) {
       const grabX = Math.floor((e.clientX - chessboard.offsetLeft) / GRID_SIZE)
       const grabY = Math.abs(
         Math.abs(
@@ -145,13 +146,14 @@ export default function Chessboard({ playMove, pieces, whoseTurn }: Props) {
 
         if (!success) {
           // Resets the piece position
-          activePiece.style.position = 'relative'
+          activePiece.style.position = 'static'
           activePiece.style.removeProperty('top')
           activePiece.style.removeProperty('left')
         }
       }
 
       setActivePiece(null)
+      document.body.style.userSelect = 'auto'
     }
   }
 

--- a/src/components/Chessboard/Chessboard.tsx
+++ b/src/components/Chessboard/Chessboard.tsx
@@ -55,7 +55,7 @@ export default function Chessboard({ playMove, pieces, whoseTurn }: Props) {
     const chessboard = chessboardRef.current
     const element = e.target as HTMLElement
 
-    if (element.classList.contains('chess-piece') && chessboard && !activePiece) {
+    if (element.classList.contains('chess-piece') && chessboard) {
       const grabX = Math.floor((e.clientX - chessboard.offsetLeft) / GRID_SIZE)
       const grabY = Math.abs(
         Math.abs(


### PR DESCRIPTION
## Minor interaction fixes

### **Description**  
- Fixes #14, allowing piece captures to work as usual for click based interaction
- Disable user selection during piece movement, which would cause unintended behaviours.

### Summary:

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Custom 🔧

---

### 🐛 Bug Fix:

- **Issue Fixed**: #14 
- **Description of Fix**: 
    - While resetting styles for a piece, set `position: static` which is its default value. `position: relative` caused it to be rendered on top, due to which it captured mouse events.  
    - Set `user-select` to `none` during piece movement, so that text selection doesn't mess with piece dragging.
- **Steps to Verify**:  
 1. Reach the following position: `1. h4 d8 g11 k7 2. Bxa9` <img src="https://github.com/user-attachments/assets/86cd1523-6e10-4870-8220-61c37db82a71" width="500" />
      
2. Click on the red bishop at a9 once.
3. Now, playing the move `bKxa9` does not have any issues.


---

### **Open Source Programs**

I am making this PR as a part of KWoC.

---

### ✅ Checklist:

- [x] My code adheres to the code style of this project.
- [x] I have run the appropriate tests for this change.
- [x] My PR references any relevant issues
